### PR TITLE
Slightly tweaked header contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ flexible criteria.
 
 ## Setup
 
-### Initial setup
+### Building pre-requisites
 ```bash
 brew install mongodb
 bundle #install required gems
 ```
 
-### Starting the web server
+### Deploying the web server
 ```bash
 bundle exec rackup
 ```
@@ -23,7 +23,7 @@ bundle exec guard
 
 ## Development
 
-### Loading sample Datashare data from XML files
+### Loading example Datashare data from XML files
 (must end with .xml extensions)
 ```bash
 thor data:load_arrest_reports /path-to-encrypted-data/NYPD


### PR DESCRIPTION
I’ve made a tiny change to the README. I have been working on a checklist for required headings in documentation, and starting to write tests against them. “Build,” “deploy” and “example” reflect the contents of these sections slightly better, and will also pass the [tests I’ve been working on](http://github-observer.s3.amazonaws.com/observations.html). Humor me? 
